### PR TITLE
FIX #MS-1: Tornar obrigatório o campo de telefone ao adicionar endereço em minha conta

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -141,7 +141,7 @@ class AddressCore extends ObjectModel
             'postcode' => ['type' => self::TYPE_STRING, 'validate' => 'isPostCode', 'size' => 12],
             'city' => ['type' => self::TYPE_STRING, 'validate' => 'isCityName', 'required' => true, 'size' => 64],
             'other' => ['type' => self::TYPE_STRING, 'validate' => 'isMessage', 'size' => FormattedTextareaType::LIMIT_MEDIUMTEXT_UTF8_MB4],
-            'phone' => ['type' => self::TYPE_STRING, 'validate' => 'isPhoneNumber', 'size' => 32],
+            'phone' => ['type' => self::TYPE_STRING, 'validate' => 'isPhoneNumber', 'required' => true, 'size' => 32],
             'phone_mobile' => ['type' => self::TYPE_STRING, 'validate' => 'isPhoneNumber', 'size' => 32],
             'dni' => ['type' => self::TYPE_STRING, 'validate' => 'isDniLite', 'size' => 16],
             'deleted' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool', 'copy_post' => false],

--- a/classes/form/CustomerAddressFormatter.php
+++ b/classes/form/CustomerAddressFormatter.php
@@ -92,6 +92,7 @@ class CustomerAddressFormatterCore implements FormFormatterInterface
                     }
                 } elseif ($field === 'phone') {
                     $formField->setType('tel');
+                    $formField->setRequired(true);
                 } elseif ($field === 'dni' && null !== $this->country) {
                     if ($this->country->need_identification_number) {
                         $formField->setRequired(true);


### PR DESCRIPTION
IFG - MANUTENÇÃO DE SOFTWARE

Anteriormente o campo telefone era opcional, não sendo obrigado o usuário a adicionar, agora modificamos para que seja obrigatório.